### PR TITLE
Allow post-save filters to be run async in a celery queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ POST_SAVE_FILTERS = [
 ]
 ```
 
+The Bioformats filter can be run outside of the default celery queue. To specify a different celery queue, add the following to MyTardis's `settings.py`:
+
+```
+BIOFORMATS_QUEUE = "nameofqueue"
+```
+where `nameofqueue` is the name of the celery queue in which you want to run the filter.
+
 # Developers
 ## Get the source
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ MyTardisBF is an App for the [MyTardis](https://github.com/mytardis/mytardis) da
 ## Installation
 Install MyTardisBF app into you MyTardis python environment:
 
-`pip install -e git+https://github.com/keithschulze/mytardisbf.git`
+`pip install -e git+https://github.com/keithschulze/mytardisbf.git@runinqueue#egg=mytardisbf`
 
 If you using a virtualenv, remember to activate it first.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ MyTardisBF is an App for the [MyTardis](https://github.com/mytardis/mytardis) da
 ## Installation
 Install MyTardisBF app into you MyTardis python environment:
 
-`pip install -e git+https://github.com/keithschulze/mytardisbf.git@runinqueue#egg=mytardisbf`
+`pip install -e git+https://github.com/keithschulze/mytardisbf.git#egg=mytardisbf`
 
 If you using a virtualenv, remember to activate it first.
 

--- a/mytardisbf/filters/metadata_filter.py
+++ b/mytardisbf/filters/metadata_filter.py
@@ -1,5 +1,6 @@
 from mytardisbf import metadata
 from mytardisbf.filters import filter_utils
+from django.conf import settings
 
 
 class MetadataFilter(object):
@@ -30,11 +31,10 @@ class MetadataFilter(object):
             Specifies whether a new record is being created.
         """
         instance = kwargs.get('instance')
+        bfqueue = getattr(settings, 'BIOFORMATS_QUEUE', 'celery')
         filter_utils.process_meta_file_output\
-            .apply_async(args=[metadata.get_meta,
-                               instance,
-                               self.schema,
-                               False])
+            .apply_async(args=[metadata.get_meta, instance, self.schema,
+                               False], queue=bfqueue)
 
 
 def make_filter(name, schema):


### PR DESCRIPTION
This PR bring capability to have post-save filters run asynchronously in specified celery queue.
